### PR TITLE
Fix: added mostly-proper Unicode support.

### DIFF
--- a/src/USBAnalyzerResults.cpp
+++ b/src/USBAnalyzerResults.cpp
@@ -1,7 +1,8 @@
 #include <iostream>
 #include <fstream>
 #include <algorithm>
-
+#include <locale>
+#include <codecvt>
 #include <stdio.h>
 
 #include <AnalyzerHelpers.h>
@@ -517,7 +518,13 @@ void GetCtrlTransFrameDesc( const Frame& frm, DisplayBase display_base, std::vec
     }
     else if( formatter == Fld_Wchar )
     {
-        desc = std::string( " char='" ) + char( val & 0xff ) + '\'';
+        // utf-8 encode the utf-16 character.
+        std::u16string utf_16_str;
+        char16_t u16_char = static_cast<char16_t>( val );
+        utf_16_str.push_back( u16_char );
+        std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> convert;
+        std::string utf8_str = convert.to_bytes( utf_16_str );
+        desc = std::string( " char='" ) + utf8_str + '\'';
     }
     else if( formatter == Fld_wLANGID )
     {

--- a/src/USBControlTransfers.h
+++ b/src/USBControlTransfers.h
@@ -233,7 +233,8 @@ class USBControlTransferParser
 
     USBRequest mRequest;
 
-    std::string stringDescriptor;
+    std::u16string utf16StringDescriptor;
+
 
     // these are only valid during a ParsePacket call, and invalid before and after
     USBPacket* pPacket;


### PR DESCRIPTION
Note, the single character decoding obviously won't work with multi code-unit characters. To fix that, the code-unit by code-unit decoding would need to be modified to detect code-units in the surrogate range, and continue decoding more code-units until a complete code-point is found. Fortunately, most languages are within the Basic Multilingual Plane.

Note, a USB capture with non-ascii characters can be found in support ticket 83241